### PR TITLE
support @noflipStart-@noflipEnd to protect multiple rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,5 +42,20 @@ Use a `/* @noflip */` comment to protect a rule from being changed.
 }
 ```
 
+Use matching `/* @noflipStart */` and `/* noflipEnd */` to protect a set of rules from being changed.
+
+```css
+/* @noflipStart */
+.rule1 {
+  /* Will be preserved as margin-left */
+  margin-left: 1em;
+}
+.rule2 {
+  /* Will be preserved as margin-left */
+  margin-left: 1em;
+}
+/* noflipEnd */
+```
+
 ## See also
 * [Interactive demo](https://cssjanus.github.io)

--- a/test/data.json
+++ b/test/data.json
@@ -729,6 +729,79 @@
 			]
 		]
 	},
+	"do not flip rules or properties betwen @noflipStart and @noflipEnd comments": {
+		"cases": [
+			[
+				"/* @noflipStart *//* @noflipEnd */"
+			],
+			[
+				"/* @noflipStart */ div { float: left; } /* @noflipEnd */"
+			],
+			[
+				"/*! @noflipStart */ div { float: left; } /*! @noflipEnd */"
+			],
+			[
+				"/*    @noflipStart    */ div { float: left; } /*    @noflipEnd    */"
+			],
+			[
+				"/*!  @noflipStart  */ div { float: left; } /*!   @noflipEnd   */"
+			],
+			[
+				"/* @noflipStart */ div { float: left; } /* @noflipEnd */ div { float: right; }",
+				"/* @noflipStart */ div { float: left; } /* @noflipEnd */ div { float: left; }"
+			],
+			[
+				"/* @noflipStart */\ndiv { float: left; }/* @noflipEnd */\ndiv { float: right; }",
+				"/* @noflipStart */\ndiv { float: left; }/* @noflipEnd */\ndiv { float: left; }"
+			],
+			[
+				"div { float: right; /* @noflipStart */ float: left; }/* @noflipEnd */",
+				"div { float: left; /* @noflipStart */ float: left; }/* @noflipEnd */"
+			],
+			[
+				"div\n{ float: right;\n/* @noflipStart */\n float: left;\n; /* @noflipEnd */ }",
+				"div\n{ float: left;\n/* @noflipStart */\n float: left;\n; /* @noflipEnd */ }"
+			],
+			[
+				"div\n{ float: right;\n/* @noflipStart */\n text-align: left\n /* @noflipEnd */ }",
+				"div\n{ float: left;\n/* @noflipStart */\n text-align: left\n /* @noflipEnd */ }"
+			],
+			[
+				"div\n{ /* @noflipStart */\ntext-align: left;\n/* @noflipEnd */ float: right\n\t}",
+				"div\n{ /* @noflipStart */\ntext-align: left;\n/* @noflipEnd */ float: left\n\t}"
+			],
+			[
+				"/* @noflipStart */div{float:left;text-align:left;}/* @noflipEnd */div{float:right}",
+				"/* @noflipStart */div{float:left;text-align:left;}/* @noflipEnd */div{float:left}"
+			],
+			[
+				"/* @noflipStart */\ndiv{float:left;text-align:left;}/* @noflipEnd */a{foo:right}",
+				"/* @noflipStart */\ndiv{float:left;text-align:left;}/* @noflipEnd */a{foo:left}"
+			],
+			[
+				"/* @noflipStart */ div.foo[bar*=baz] { left: 10px; float: left; }/* @noflipEnd */"
+			],
+			[
+				"/* @noflipStart */ div.foo[bar^=baz] { left: 10px; float: left; }/* @noflipEnd */"
+			],
+			[
+				"/* @noflipStart */ div.foo[bar~=baz] { left: 10px; float: left; }/* @noflipEnd */"
+			],
+			[
+				"/* @noflipStart */ div.foo[bar=baz] { left: 10px; float: left; }/* @noflipEnd */"
+			],
+			[
+				"/* @noflipStart */ div.foo[bar*='baz{quux'] { left: 10px; float: left; }/* @noflipEnd */"
+			],
+			[
+				"/* @noflipStart */ div { float: left; } /* @noflipEnd */ div { float: left; } /* @noflipStart */ div { float: right; } /* @noflipEnd */",
+				"/* @noflipStart */ div { float: left; } /* @noflipEnd */ div { float: right; } /* @noflipStart */ div { float: right; } /* @noflipEnd */"
+			],
+			[
+				"/* @noflipStart */ div { float: left; } /* @noflipEnd */ /* @noflip */ div { float: left; } /* @noflipStart */ div { float: right; } /* @noflipEnd */"
+			]
+		]
+	},
 	"do not flip gradient notation": {
 		"cases": [
 			[


### PR DESCRIPTION
Tests and docs included.
Fixes #28

I got some lint errors from jscs. I also got them on the master branch so I ignore them for now. If the travis build will fail I'll submit another commit to fix them.

```
Running "jscs:all" (jscs) task
Invalid line break at Gruntfile.js :
     1 |module.exports = function ( grunt ) {
---------------------------------------------^
     2 | grunt.loadNpmTasks( 'grunt-contrib-jshint' );
     3 | grunt.loadNpmTasks( 'grunt-contrib-watch' );
Invalid line break at build/tasks/unit.js :
     1 |module.exports = function ( grunt ) {
---------------------------------------------^
     2 | grunt.registerTask( 'unit', function () {
     3 |  var assert = require( 'assert' ),
Invalid line break at src/cssjanus.js :
     1 |/*!
-----------^
     2 | * Converts CSS stylesheets between left-to-right and right-to-left.
     3 | * https://github.com/cssjanus/cssjanus
Multiple line break at src/cssjanus.js :
   252 |    noFlipMultipleTokenizer = new Tokenizer( noFlipMultipleRegExp,  noFlipMultipleToken ),
   253 |    commentTokenizer = new Tokenizer( commentRegExp, commentToken );
   254 |
--------^
   255 |
   256 |   // Tokenize
>> 4 code style errors found!
Warning: Task "jscs:all" failed. Use --force to continue.
```
