### PR TITLE
text-shadow with blur radius is flipped wrong

### DIFF
--- a/test/data.json
+++ b/test/data.json
@@ -232,6 +232,13 @@
 				".foo { text-shadow: -2px 0 red; }"
 			],
 			[
+				".foo { text-shadow: 15px 10px 30px red; }",
+				".foo { text-shadow: -15px 10px 30px red; }"
+			],
+			[
+				".foo { text-shadow: 0 1px 3px red; }"
+			],
+			[
 				".foo { text-shadow: red 0 2px; }"
 			]
 		]


### PR DESCRIPTION
The flipped version of `0 1px 3px rgba( 0, 0, 0, 0.4 );` is currently `text-shadow: 0 -1px 3px rgba( 0, 0, 0, 0.4 );`. But this is wrong, it should be the same since the second value is the y-coordinate.

deb10e9 adds two new test cases, will try to fix them.

BTW: text-shadow supports multiple text shadows separated by comma.
