### PR TITLE
test: Add test for 3-values border-radius

### DIFF
--- a/build/tasks/unit.js
+++ b/build/tasks/unit.js
@@ -7,7 +7,7 @@ module.exports = function ( grunt ) {
 			testData = require( '../../test/data.json' ),
 			failures = 0,
 			tests = 0,
-			name, test, args, i, input, noop, output;
+			name, test, args, i, input, noop, roundtrip, output;
 
 		for ( name in testData ) {
 			tests++;
@@ -19,6 +19,7 @@ module.exports = function ( grunt ) {
 					input = test.cases[ i ][ 0 ];
 					noop = test.cases[ i ][ 1 ] === undefined;
 					output = noop ? input : test.cases[ i ][ 1 ];
+					roundtrip = test.roundtrip !== undefined ? test.roundtrip : !noop;
 
 					assert.equal(
 						cssjanus.transform(
@@ -29,7 +30,7 @@ module.exports = function ( grunt ) {
 						output
 					);
 
-					if ( !noop ) {
+					if ( roundtrip ) {
 						// Round-trip
 						assert.equal(
 							cssjanus.transform(

--- a/test/data.json
+++ b/test/data.json
@@ -391,6 +391,15 @@
 			]
 		]
 	},
+	"flip border-radius (one-way)": {
+		"roundtrip": false,
+		"cases": [
+			[
+				".foo { border-radius: 1px 2px 3px; }",
+				".foo { border-radius: 2px 1px 2px 3px; }"
+			]
+		]
+	},
 	"flip border-top-{edge}-radius": {
 		"cases": [
 			[


### PR DESCRIPTION
Should help increase the code coverage and overall stability.
This wasn't previously done because the test runner insisted
on roundtripping all test cases, which isn't possible in this case.

```
input: 1px 2px 3px      -> output: 2px 1px 2px 3px
// Same as:
input: 1px 2px 3px 2px  -> output: 2px 1px 2px 3px

and:

```
input: 2px 1px 2px 3px  -> output: 1px 2px 3px 2px
// of which the output is effectively the same as "1px 2px 3px"
```

When 3 values are given in CSS, the fourth value is implied to be the same
as the second value:
```
(top, [right=top], [bottom=top], [left=right])
```
Add a "roundtrip" setting to disable roundtripping where needed.