### PR TITLE
Accept double-quotes, comments in selectors

### DIFF
--- a/src/cssjanus.js
+++ b/src/cssjanus.js
@@ -119,7 +119,7 @@ function CSSJanus() {
 		colorPattern = '(#?' + nmcharPattern + '+|(?:rgba?|hsla?)\\([ \\d.,%-]+\\))',
 		urlCharsPattern = '(?:' + urlSpecialCharsPattern + '|' + nonAsciiPattern + '|' + escapePattern + ')*',
 		lookAheadNotLetterPattern = '(?![a-zA-Z])',
-		lookAheadNotOpenBracePattern = '(?!(' + nmcharPattern + '|\\r?\\n|\\s|#|\\:|\\.|\\,|\\+|>|\\(|\\)|\\[|\\]|=|\\*=|~=|\\^=|\'[^\']*\'])*?{)',
+		lookAheadNotOpenBracePattern = '(?!(' + nmcharPattern + '|\\r?\\n|\\s|#|\\:|\\.|\\,|\\+|>|\\(|\\)|\\[|\\]|=|\\*=|~=|\\^=|\'[^\']*\'|"[^"]*"|' + commentToken + ')*?{)',
 		lookAheadNotClosingParenPattern = '(?!' + urlCharsPattern + '?' + validAfterUriCharsPattern + '\\))',
 		lookAheadForClosingParenPattern = '(?=' + urlCharsPattern + '?' + validAfterUriCharsPattern + '\\))',
 		suffixPattern = '(\\s*(?:!important\\s*)?[;}])',

--- a/test/data.json
+++ b/test/data.json
@@ -754,6 +754,12 @@
 			],
 			[
 				".a-foo.png { width: 0; }"
+			],
+			[
+				".foo-left /* comment */ { color: red; }"
+			],
+			[
+				"[class*=\"span\"].pull-right,.row-fluid [class*=\"span\"].pull-right { color: red; }"
 			]
 		]
 	},


### PR DESCRIPTION
Change lookAheadNotOpenBracePattern to allow selectors to match "" patterns (eg [class="span"]) and selectors with comments interspersed. This fixes issue #35, where text before either comments or attribute selectors using double quotes were not being considered part of the selector, and having text flipped as though they were part of rules. (Eg `.right [class="span"] { float: right; }` was flipped to `.left` .)