### PR TITLE
build: Bump devDependencies (grunt)

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {},
   "devDependencies": {
     "eslint-config-wikimedia": "0.3.0",
-    "grunt": "1.0.1",
+    "grunt": "1.0.2",
     "grunt-contrib-watch": "1.0.0",
     "grunt-eslint": "18.0.0",
     "grunt-jsonlint": "1.0.8"


### PR DESCRIPTION
* grunt 1.0.1 → 1.0.2
  - Removes grunt's dependency on the deprecated 'coffee-script' package,
    by using 'coffeescript' instead.
    This fixes a warning shown during `npm install` when developing cssjanus
    locally.