### PR TITLE
Fix unicodePattern, add test

### DIFF
--- a/src/cssjanus.js
+++ b/src/cssjanus.js
@@ -98,7 +98,7 @@ function CSSJanus() {
 		commentToken = '`COMMENT`',
 		// Patterns
 		nonAsciiPattern = '[^\\u0020-\\u007e]',
-		unicodePattern = '(?:(?:\\[0-9a-f]{1,6})(?:\\r\\n|\\s)?)',
+		unicodePattern = '(?:(?:\\\\[0-9a-f]{1,6})(?:\\r\\n|\\s)?)',
 		numPattern = '(?:[0-9]*\\.[0-9]+|[0-9]+)',
 		unitPattern = '(?:em|ex|px|cm|mm|in|pt|pc|deg|rad|grad|ms|s|hz|khz|%)',
 		directionPattern = 'direction\\s*:\\s*',

--- a/test/data.json
+++ b/test/data.json
@@ -754,6 +754,9 @@
 			],
 			[
 				".a-foo.png { width: 0; }"
+			],
+			[
+				"a.padding-left .\\31 { color: red; }"
 			]
 		]
 	},


### PR DESCRIPTION
The pattern `unicodePattern`, presumably intended to match things like "`\31`", had only two slashes in the pattern, and was thus simply escaping the following `[` in `[0-9a-f]`. This pull request fixes the pattern and adds a test for this.