### PR TITLE
Require Node 6 & build dev dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 sudo: false
 language: node_js
 node_js:
+  - "10"
   - "8"
   - "6"
-  - "4"
 notifications:
   irc:
     channels:

--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
   "dependencies": {},
   "devDependencies": {
     "eslint-config-wikimedia": "0.3.0",
-    "grunt": "1.0.2",
-    "grunt-contrib-watch": "1.0.0",
-    "grunt-eslint": "18.0.0",
-    "grunt-jsonlint": "1.0.8"
+    "grunt": "1.0.3",
+    "grunt-contrib-watch": "1.1.0",
+    "grunt-eslint": "21.0.0",
+    "grunt-jsonlint": "1.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test": "grunt test"
   },
   "engines": {
-    "node": ">=4.0.0"
+    "node": ">=6.0.0"
   },
   "dependencies": {},
   "devDependencies": {


### PR DESCRIPTION
Dropping Node 4 (EOL) before cutting the next release.