### PR TITLE
build: Add npm-run command for 'grunt site'

### DIFF
--- a/build/tasks/site.js
+++ b/build/tasks/site.js
@@ -3,9 +3,9 @@
 module.exports = function ( grunt ) {
 	grunt.registerTask( 'site', function () {
 		var from = 'site/',
-			// E.g. 'grunt site --dest ../cssjanus.github.io'
+			// E.g. `DEST="../cssjanus.github.io" npm run site`
 			// Ensure 'to' path ends in a slash
-			to = ( grunt.option( 'dest' ) || 'dest/' ).replace( /\/?$/, '/' ),
+			to = ( process.env.DEST || 'dest/' ).replace( /\/?$/, '/' ),
 			paths = [
 				'/demo/',
 				'/lib/',

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "LICENSE.txt"
   ],
   "scripts": {
-    "test": "grunt test"
+    "test": "grunt test",
+    "site": "grunt site"
   },
   "engines": {
     "node": ">=6.0.0"


### PR DESCRIPTION
Previously one had to install grunt-cli globally in the local
shell (or use npx). Instead, add a preset command that uses
the locally installed copy of grunt, same as for `npm test`.

Also, update the destination directory option to be based
on an environment variable because passing options from an
npm script is not user-friendly (would have to require four dashes
instead of two, e.g. `npm run site -- --foo bar`), and more
importantly, Grunt specifically does not support this call
pattern and instead tries to look for a task called "--foo".

Avoid that issue by using an env variable instead.