### PR TITLE
Fix a bug that was changing wrongly the percentages in linear-gradient background properties

### DIFF
--- a/src/cssjanus.js
+++ b/src/cssjanus.js
@@ -145,7 +145,7 @@ function CSSJanus() {
 		cursorWestRegExp = new RegExp( nonLetterPattern + '([ns]?)w-resize', 'gi' ),
 		fourNotationQuantRegExp = new RegExp( fourNotationQuantPropsPattern + signedQuantPattern + '(\\s+)' + signedQuantPattern + '(\\s+)' + signedQuantPattern + '(\\s+)' + signedQuantPattern + suffixPattern, 'gi' ),
 		fourNotationColorRegExp = new RegExp( fourNotationColorPropsPattern + colorPattern + '(\\s+)' + colorPattern + '(\\s+)' + colorPattern + '(\\s+)' + colorPattern + suffixPattern, 'gi' ),
-		bgHorizontalPercentageRegExp = new RegExp( '(background(?:-position)?\\s*:\\s*(?:[^:;}\\s]+\\s+)*?)(' + quantPattern + ')', 'gi' ),
+		bgHorizontalPercentageRegExp = new RegExp( '(background(?:-position)?\\s*:\\s*(?:(?!linear-gradient)[^:;}\\s]+\\s+)*?)(' + quantPattern + ')', 'gi' ),
 		bgHorizontalPercentageXRegExp = new RegExp( '(background-position-x\\s*:\\s*)(-?' + numPattern + '%)', 'gi' ),
 		// border-radius: <length or percentage>{1,4} [optional: / <length or percentage>{1,4} ]
 		borderRadiusRegExp = new RegExp( '(border-radius\\s*:\\s*)' + signedQuantPattern + '(?:(?:\\s+' + signedQuantPattern + ')(?:\\s+' + signedQuantPattern + ')?(?:\\s+' + signedQuantPattern + ')?)?' +

--- a/test/data.json
+++ b/test/data.json
@@ -578,6 +578,10 @@
 			[
 				".foo  {  background:  url(/foo/bar.png) 77% 40%  ;  }",
 				".foo  {  background:  url(/foo/bar.png) 23% 40%  ;  }"
+			],
+			[
+				".foo { background: url(/foo/bright.png) 20% 50%, linear-gradient( red 10%, blue ); }",
+				".foo { background: url(/foo/bright.png) 80% 50%, linear-gradient( red 10%, blue ); }"
 			]
 		]
 	},
@@ -605,6 +609,31 @@
 		"cases": [
 			[
 				".foo { background-position-y: 40%; }"
+			]
+		]
+	},
+	"do not flip gradient notation": {
+		"cases": [
+			[
+				".foo { background-image: -moz-linear-gradient(#326cc1, #234e8c); }"
+			],
+			[
+				".foo { background-image: -webkit-gradient(linear, 100% 0%, 0% 0%, from(#666666), to(#ffffff)); }"
+			]
+		]
+	},
+	"do not change percentages in linear gradient": {
+		"cases": [
+			[
+				".foo { background: linear-gradient(to left, #00ff00 0%, #ff0000 100%); }",
+				".foo { background: linear-gradient(to right, #00ff00 0%, #ff0000 100%); }"
+			],
+			[
+				".foo { background: linear-gradient(to left, #00ff00 0, #ff0000 100%); }",
+				".foo { background: linear-gradient(to right, #00ff00 0, #ff0000 100%); }"
+			],
+			[
+				".foo { background: linear-gradient( red 10%, blue ); }"
 			]
 		]
 	},
@@ -853,16 +882,6 @@
 			],
 			[
 				"/* @noflip */ div.foo[bar*='baz{quux'] { left: 10px; float: left; }"
-			]
-		]
-	},
-	"do not flip gradient notation": {
-		"cases": [
-			[
-				".foo { background-image: -moz-linear-gradient(#326cc1, #234e8c); }"
-			],
-			[
-				".foo { background-image: -webkit-gradient(linear, 100% 0%, 0% 0%, from(#666666), to(#ffffff)); }"
 			]
 		]
 	},


### PR DESCRIPTION
The regular expression bgHorizontalPercentageRegExp was matching strings like this one:
    
```
background: linear-gradient(to left, #00ff00 0%, #ff0000 100%);
```
    
* match: `background: linear-gradient(to left, #00ff00 0%`
* pre: `linear-gradient(to left, #00ff00`
* value: `0%`
    
This was causing that the previous string changed to:
    
```
background: linear-gradient(to right, #00ff00 100%, #ff0000 100%);
```
    
This commit avoids to match background properties that start with `linear-gradient`
